### PR TITLE
Fix cut-off and expansion issues with MODE, which is a possible probl…

### DIFF
--- a/include/h.h
+++ b/include/h.h
@@ -665,7 +665,6 @@ extern char *spamfilter_inttostring_long(int v);
 extern MODVAR char backupbuf[];
 extern int is_invited(Client *client, Channel *channel);
 extern void channel_modes(Client *client, char *mbuf, char *pbuf, size_t mbuf_size, size_t pbuf_size, Channel *channel, int hide_local_modes);
-extern MODVAR char modebuf[BUFSIZE], parabuf[BUFSIZE];
 extern int op_can_override(const char *acl, Client *client,Channel *channel,void* extra);
 extern Client *find_chasing(Client *client, const char *user, int *chasing);
 extern MODVAR long opermode;
@@ -708,8 +707,8 @@ extern MODVAR void (*do_join)(Client *, int, const char **);
 extern MODVAR void (*join_channel)(Channel *channel, Client *client, MessageTag *mtags, const char *flags);
 extern MODVAR int (*can_join)(Client *client, Channel *channel, const char *key, char **errmsg);
 extern MODVAR void (*do_mode)(Channel *channel, Client *client, MessageTag *mtags, int parc, const char *parv[], time_t sendts, int samode);
-extern MODVAR void (*set_mode)(Channel *channel, Client *cptr, int parc, const char *parv[], u_int *pcount,
-    char pvar[MAXMODEPARAMS][MODEBUFLEN + 3]);
+extern MODVAR MultiLineMode *(*set_mode)(Channel *channel, Client *cptr, int parc, const char *parv[], u_int *pcount,
+                            char pvar[MAXMODEPARAMS][MODEBUFLEN + 3]);
 extern MODVAR void (*set_channel_mode)(Channel *channel, char *modes, char *parameters);
 extern MODVAR void (*cmd_umode)(Client *, MessageTag *, int, const char **);
 extern MODVAR int (*register_user)(Client *client);
@@ -1032,6 +1031,8 @@ extern int should_show_connect_info(Client *client);
 extern void send_invalid_channelname(Client *client, const char *channelname);
 extern int is_extended_ban(const char *str);
 extern int empty_mode(const char *m);
+extern void free_multilinemode(MultiLineMode *m);
+#define safe_free_multilinemode(m) do { if (m) free_multilinemode(m); m = NULL; } while(0)
 extern int valid_sid(const char *name);
 extern int valid_uid(const char *name);
 extern void parse_client_queued(Client *client);

--- a/include/modules.h
+++ b/include/modules.h
@@ -1489,9 +1489,10 @@ int hooktype_pre_remote_chanmode(Client *client, Channel *channel, MessageTag *m
  * @param parabuf		The parameter buffer, for example "NiceOp"
  * @param sendts		Send timestamp
  * @param samode		Is this an SAMODE?
+ * @param destroy_channel	Module can set this to 1 to indicate 'channel' was destroyed
  * @return The return value is ignored (use return 0)
  */
-int hooktype_local_chanmode(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode);
+int hooktype_local_chanmode(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode, int *destroy_channel);
 
 /** Called when a remote user changes channel modes (function prototype for HOOKTYPE_REMOTE_CHANMODE).
  * @param client		The client
@@ -1501,9 +1502,10 @@ int hooktype_local_chanmode(Client *client, Channel *channel, MessageTag *mtags,
  * @param parabuf		The parameter buffer, for example "NiceOp"
  * @param sendts		Send timestamp
  * @param samode		Is this an SAMODE?
+ * @param destroy_channel	Module can set this to 1 to indicate 'channel' was destroyed
  * @return The return value is ignored (use return 0)
  */
-int hooktype_remote_chanmode(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode);
+int hooktype_remote_chanmode(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode, int *destroy_channel);
 
 /** Called when a channel mode is removed by a local or remote user (function prototype for HOOKTYPE_MODECHAR_DEL).
  * NOTE: This is currently not terribly useful for most modules. It is used by by the floodprot and noknock modules.

--- a/include/struct.h
+++ b/include/struct.h
@@ -2096,6 +2096,14 @@ struct ParseMode {
 	char buf[512]; /* internal parse buffer */
 };
 
+#define MAXMULTILINEMODES       3
+typedef struct MultiLineMode MultiLineMode;
+struct MultiLineMode {
+	char *modeline[MAXMULTILINEMODES+1];
+	char *paramline[MAXMULTILINEMODES+1];
+	int numlines;
+};
+
 typedef struct PendingServer PendingServer;
 struct PendingServer {
 	PendingServer *prev, *next;

--- a/src/api-efunctions.c
+++ b/src/api-efunctions.c
@@ -38,8 +38,8 @@ void (*do_join)(Client *client, int parc, const char *parv[]);
 void (*join_channel)(Channel *channel, Client *client, MessageTag *mtags, const char *member_modes);
 int (*can_join)(Client *client, Channel *channel, const char *key, char **errmsg);
 void (*do_mode)(Channel *channel, Client *client, MessageTag *mtags, int parc, const char *parv[], time_t sendts, int samode);
-void (*set_mode)(Channel *channel, Client *client, int parc, const char *parv[], u_int *pcount,
-    char pvar[MAXMODEPARAMS][MODEBUFLEN + 3]);
+MultiLineMode *(*set_mode)(Channel *channel, Client *client, int parc, const char *parv[], u_int *pcount,
+                           char pvar[MAXMODEPARAMS][MODEBUFLEN + 3]);
 void (*set_channel_mode)(Channel *channel, char *modes, char *parameters);
 void (*cmd_umode)(Client *client, MessageTag *mtags, int parc, const char *parv[]);
 int (*register_user)(Client *client);

--- a/src/channel.c
+++ b/src/channel.c
@@ -40,12 +40,8 @@ long sajoinmode = 0;
  */
 Channel *channels = NULL;
 
-/* some buffers for rebuilding channel/nick lists with comma's */
+/* A buffer for rebuilding channel/nick lists with comma's */
 static char buf[BUFSIZE];
-/** Mode buffer (eg: "+sntkl") */
-MODVAR char modebuf[BUFSIZE];
-/** Parameter buffer (eg: "key 123") */
-MODVAR char parabuf[BUFSIZE];
 
 static mp_pool_t *channel_pool = NULL;
 
@@ -1311,4 +1307,18 @@ int empty_mode(const char *m)
 	if (!*m || (((m[0] == '+') || (m[0] == '-')) && m[1] == '\0'))
 		return 1;
 	return 0;
+}
+
+/** Free everything of/in a MultiLineMode */
+void free_multilinemode(MultiLineMode *m)
+{
+	int i;
+	if (m == NULL)
+		return;
+	for (i=0; i < m->numlines; i++)
+	{
+		safe_free(m->modeline[i]);
+		safe_free(m->paramline[i]);
+	}
+	safe_free(m);
 }

--- a/src/modules/chanmodes/history.c
+++ b/src/modules/chanmodes/history.c
@@ -44,7 +44,7 @@ static void init_config(cfgstruct *cfg);
 int history_config_test(ConfigFile *, ConfigEntry *, int, int *);
 int history_config_posttest(int *);
 int history_config_run(ConfigFile *, ConfigEntry *, int);
-int history_chanmode_change(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode);
+int history_chanmode_change(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode, int *destroy_channel);
 static int compare_history_modes(HistoryChanMode *a, HistoryChanMode *b);
 int history_chanmode_is_ok(Client *client, Channel *channel, char mode, const char *para, int type, int what);
 void *history_chanmode_put_param(void *r_in, const char *param);
@@ -610,7 +610,7 @@ int history_chanmode_sjoin_check(Channel *channel, void *ourx, void *theirx)
 }
 
 /** On channel mode change, communicate the +H limits to the history backend layer */
-int history_chanmode_change(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode)
+int history_chanmode_change(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode, int *destroy_channel)
 {
 	HistoryChanMode *settings;
 
@@ -769,6 +769,7 @@ CMD_OVERRIDE_FUNC(override_mode)
 		{
 			MessageTag *mtags = NULL;
 			const char *params = history_chanmode_get_param(settings);
+			char modebuf[BUFSIZE], parabuf[BUFSIZE];
 
 			if (!params)
 				return; /* Weird */

--- a/src/modules/chanmodes/issecure.c
+++ b/src/modules/chanmodes/issecure.c
@@ -48,7 +48,7 @@ int issecure_part(Client *client, Channel *channel, MessageTag *mtags, const cha
 int issecure_quit(Client *client, MessageTag *mtags, const char *comment);
 int issecure_kick(Client *client, Client *victim, Channel *channel, MessageTag *mtags, const char *comment);
 int issecure_chanmode(Client *client, Channel *channel, MessageTag *mtags,
-                             const char *modebuf, const char *parabuf, time_t sendts, int samode);
+                             const char *modebuf, const char *parabuf, time_t sendts, int samode, int *destroy_channel);
                              
 
 MOD_TEST()
@@ -248,7 +248,7 @@ int issecure_kick(Client *client, Client *victim, Channel *channel, MessageTag *
 }
 
 int issecure_chanmode(Client *client, Channel *channel, MessageTag *mtags,
-                             const char *modebuf, const char *parabuf, time_t sendts, int samode)
+                             const char *modebuf, const char *parabuf, time_t sendts, int samode, int *destroy_channel)
 {
 	if (!strchr(modebuf, 'z'))
 		return 0; /* don't care */

--- a/src/modules/chanmodes/permanent.c
+++ b/src/modules/chanmodes/permanent.c
@@ -51,14 +51,17 @@ static int permanent_is_ok(Client *client, Channel *channel, char mode, const ch
 	return EX_ALLOW;
 }
 
-int permanent_chanmode(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode)
+int permanent_chanmode(Client *client, Channel *channel, MessageTag *mtags, const char *modebuf, const char *parabuf, time_t sendts, int samode, int *destroy_channel)
 {
 	if (samode == -1)
 		return 0; /* SJOIN server-sync, already has its own way of destroying the channel */
 
 	/* Destroy the channel if it was set '(SA)MODE #chan -P' with nobody in it (#4442) */
 	if (!(channel->mode.mode & EXTMODE_PERMANENT) && (channel->users <= 0))
+	{
 		sub1_from_channel(channel);
+		*destroy_channel = 1;
+	}
 	
 	return 0;
 }

--- a/src/modules/channeldb.c
+++ b/src/modules/channeldb.c
@@ -331,6 +331,8 @@ int write_listmode(UnrealDB *db, const char *tmpfname, Ban *lst)
 
 int write_channel_entry(UnrealDB *db, const char *tmpfname, Channel *channel)
 {
+	char modebuf[BUFSIZE], parabuf[BUFSIZE];
+
 	W_SAFE(unrealdb_write_int32(db, MAGIC_CHANNEL_START));
 	/* Channel name */
 	W_SAFE(unrealdb_write_str(db, channel->name));

--- a/src/modules/join.c
+++ b/src/modules/join.c
@@ -261,6 +261,7 @@ void _join_channel(Channel *channel, Client *client, MessageTag *recv_mtags, con
 		{
 			MessageTag *mtags_mode = NULL;
 			Cmode *cm;
+			char modebuf[BUFSIZE], parabuf[BUFSIZE];
 
 			channel->mode.mode = MODES_ON_JOIN;
 

--- a/src/modules/list.c
+++ b/src/modules/list.c
@@ -54,6 +54,7 @@ struct ChannelListOptions {
 
 /* Global variables */
 ModDataInfo *list_md = NULL;
+char modebuf[BUFSIZE], parabuf[BUFSIZE];
 
 /* Macros */
 #define CHANNELLISTOPTIONS(x)       ((ChannelListOptions *)moddata_local_client(x, list_md).ptr)

--- a/src/modules/server.c
+++ b/src/modules/server.c
@@ -1598,6 +1598,7 @@ void send_channel_modes_sjoin3(Client *to, Channel *channel)
 	char *p; /* points to somewhere in 'tbuf' */
 	int prebuflen = 0; /* points to after the <sjointoken> <TS> <chan> <fixmodes> <fixparas <..>> : part */
 	int sent = 0; /* we need this so we send at least 1 message about the channel (eg if +P and no members, no bans, #4459) */
+	char modebuf[BUFSIZE], parabuf[BUFSIZE];
 
 	if (*channel->name != '#')
 		return;

--- a/src/modules/sjoin.c
+++ b/src/modules/sjoin.c
@@ -35,6 +35,8 @@ ModuleHeader MOD_HEADER
 	"unrealircd-6",
     };
 
+char modebuf[BUFSIZE], parabuf[BUFSIZE];
+
 MOD_INIT()
 {
 	CommandAdd(modinfo->handle, MSG_SJOIN, cmd_sjoin, MAXPARA, CMD_SERVER);
@@ -238,6 +240,10 @@ CMD_FUNC(cmd_sjoin)
 			MessageTag *mtags = NULL;
 			ap = mp2parv(modebuf, parabuf);
 			set_mode(channel, client, ap->parc, ap->parv, &pcount, pvar);
+			/* Hm.. originally modebuf & parabuf were returned via set_mode(), but
+			 * now we use the result from channel_modes().. is that correct?
+			 * They should not differ, right? Still not sure about it, though.
+			 */
 			send_local_chan_mode(recv_mtags, client, channel, modebuf, parabuf);
 		}
 		/* remove bans */

--- a/src/modules/stats.c
+++ b/src/modules/stats.c
@@ -780,6 +780,7 @@ int stats_set(Client *client, const char *para)
 	char *uhallow;
 	SecurityGroup *s;
 	FloodSettings *f;
+	char modebuf[BUFSIZE], parabuf[BUFSIZE];
 
 	if (!ValidatePermissionsForPath("server:info:stats",client,NULL,NULL,NULL))
 	{

--- a/src/modules/svsmode.c
+++ b/src/modules/svsmode.c
@@ -42,6 +42,8 @@ ModuleHeader MOD_HEADER
 	"unrealircd-6",
     };
 
+char modebuf[BUFSIZE], parabuf[BUFSIZE];
+
 MOD_INIT()
 {
 	CommandAdd(modinfo->handle, MSG_SVSMODE, cmd_svsmode, MAXPARA, CMD_SERVER|CMD_USER);


### PR DESCRIPTION
…em when

using mixed UnrealIRCd 5 and UnrealIRCd 6 networks.

This is a slightly complex rewrite of make_mode_str() and do_mode(),
as we nog go from single mode lines to potentially multiple mode lines.

In short: whenever we would be near buffer cut-off point (the famous
512 byte limit) then previously we would prevent the mode, though not
succesfully in all cases where a network consists of mixed 5.x and 6.x.
From this point onward we no longer do that. Instead we convert one
MODE command to two MODE lines if that is needed.
The benefit of this is that we no longer prevent it BEFORE processing
the MODE, which is a flawed method and could be wrong (causing desyncs).
And also, we no longer partially ignore MODE lines from clients when
they would cause the limit to be exceeded, as we replace them with
two MODE lines instead.

These are more changes than I wanted at such a late point but.. they seem
to be necessary to prevent U5-U6 compatibility issues.