### PR TITLE
Cut off channel for KICK at first comma, as we did in U3.2/U4/U5.

### DIFF
--- a/src/modules/kick.c
+++ b/src/modules/kick.c
@@ -168,6 +168,7 @@ CMD_FUNC(cmd_kick)
 	int maxtargets = max_targets_for_command("KICK");
 	MessageTag *mtags;
 	char request[BUFSIZE];
+	char request_chans[BUFSIZE];
 	const char *client_member_modes = NULL;
 	const char *target_member_modes;
 
@@ -182,10 +183,14 @@ CMD_FUNC(cmd_kick)
 	else
 		strlncpy(comment, parv[3], sizeof(comment), iConf.kick_length);
 
-	channel = find_channel(parv[1]);
+	strlcpy(request_chans, parv[1], sizeof(request_chans));
+	p = strchr(request_chans, ',');
+	if (p)
+		*p = '\0';
+	channel = find_channel(request_chans);
 	if (!channel)
 	{
-		sendnumeric(client, ERR_NOSUCHCHANNEL, parv[1]);
+		sendnumeric(client, ERR_NOSUCHCHANNEL, request_chans);
 		return;
 	}
 
@@ -219,7 +224,7 @@ CMD_FUNC(cmd_kick)
 		if (!lp)
 		{
 			if (MyUser(client))
-				sendnumeric(client, ERR_USERNOTINCHANNEL, user, parv[1]);
+				sendnumeric(client, ERR_USERNOTINCHANNEL, user, request_chans);
 			continue;
 		}
 


### PR DESCRIPTION
Reported by progval in https://bugs.unrealircd.org/view.php?id=6015