### PR TITLE
Add new hook type for remote-to-local kills

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -1260,6 +1260,9 @@ extern void SavePersistentLongLongX(ModuleInfo *modinfo, const char *varshortnam
 /** See hooktype_reconfigure_web_listener */
 #define HOOKTYPE_CONFIG_LISTENER	120
 
+/** See hooktype_pre_remote_to_local_kill() */
+#define HOOKTYPE_PRE_REMOTE_TO_LOCAL_KILL 254
+
 /* Adding a new hook here?
  * 1) Add the #define HOOKTYPE_.... with a new number
  * 2) Add a hook prototype (see below)
@@ -1703,6 +1706,18 @@ int hooktype_who_status(Client *client, Client *target, Channel *channel, Member
  * @retval EX_ALLOW		Allow the kick, unless another module blocks it.
  */
 int hooktype_pre_kill(Client *client, Client *victim, const char *reason);
+
+/** Called when a remote IRCOp wants to kill a local user (function prototype for HOOKTYPE_PRE_REMOTE_TO_LOCAL_KILL).
+ * Other servers will have already killed the user and removed it from memory. 
+ * If you EX_DENY here you are expected to handle the fallout yourself.
+ * @param client		The client
+ * @param victim		The user who should be killed
+ * @param reason		The kill reason
+ * @retval EX_DENY		Deny the KICK (unless IRCOp with sufficient override rights).
+ * @retval EX_ALWAYS_DENY	Deny the KICK always (even if IRCOp).
+ * @retval EX_ALLOW		Allow the kick, unless another module blocks it.
+ */
+int hooktype_pre_remote_to_local_kill(Client *client, Client *victim, const char *reason);
 
 /** Called when a local user kills another user (function prototype for HOOKTYPE_LOCAL_KILL).
  * Note that kills from remote IRCOps will show up as regular quits, so use hooktype_remote_quit() and hooktype_local_quit().
@@ -2423,6 +2438,7 @@ _UNREAL_ERROR(_hook_error_incompatible, "Incompatible hook function. Check argum
         ((hooktype == HOOKTYPE_WHO_STATUS) && !ValidateHook(hooktype_who_status, func)) || \
         ((hooktype == HOOKTYPE_MODE_DEOP) && !ValidateHook(hooktype_mode_deop, func)) || \
         ((hooktype == HOOKTYPE_PRE_KILL) && !ValidateHook(hooktype_pre_kill, func)) || \
+        ((hooktype == HOOKTYPE_PRE_REMOTE_TO_LOCAL_KILL) && !ValidateHook(hooktype_pre_remote_to_local_kill, func)) || \
         ((hooktype == HOOKTYPE_SEE_CHANNEL_IN_WHOIS) && !ValidateHook(hooktype_see_channel_in_whois, func)) || \
         ((hooktype == HOOKTYPE_DCC_DENIED) && !ValidateHook(hooktype_dcc_denied, func)) || \
         ((hooktype == HOOKTYPE_SERVER_HANDSHAKE_OUT) && !ValidateHook(hooktype_server_handshake_out, func)) || \

--- a/src/modules/kill.c
+++ b/src/modules/kill.c
@@ -134,6 +134,17 @@ CMD_FUNC(cmd_kill)
 			}
 			if ((ret == EX_DENY) || (ret == EX_ALWAYS_DENY))
 				continue; /* reject kill for this particular user */
+		} else if(MyUser(target)) {
+			int ret = EX_ALLOW;
+			for (h = Hooks[HOOKTYPE_PRE_REMOTE_TO_LOCAL_KILL]; h; h = h->next)
+			{
+				/* note: parameters are: client, victim, reason. reason can be NULL !! */
+				ret = (*(h->func.intfunc))(client, target, reason);
+				if (ret != EX_ALLOW)
+					break;
+			}
+			if ((ret == EX_DENY) || (ret == EX_ALWAYS_DENY))
+				continue; /* reject kill for this particular user */
 		}
 
 		/* From here on, the kill is probably going to be successful. */


### PR DESCRIPTION
Allows modules to hook into remote->local KILL's, as HOOKTYPE_PRE_KILL only gets called for local->local and local->remote kills.

I didn't know if this was a candidate to upstream or not, so, decided to PR it here instead. Would likely be worth co-operating with the unreal team to see if this is a change they'd like upstream.